### PR TITLE
Link to Algorand Python GitHub docs for now

### DIFF
--- a/docs/get-details/dapps/writing-contracts/.pages
+++ b/docs/get-details/dapps/writing-contracts/.pages
@@ -1,6 +1,7 @@
 title: Writing Smart Contracts  
 
 arrange:
+  - python.md
   - pyteal.md
   - beaker.md
   

--- a/docs/get-details/dapps/writing-contracts/beaker.md
+++ b/docs/get-details/dapps/writing-contracts/beaker.md
@@ -1,5 +1,8 @@
 title: Beaker
 
+!!! note
+For a native Python experience, checkout our [Algorand Python](https://algorandfoundation.github.io/puya/) docs.
+
 Beaker is a framework for building Smart Contracts using PyTeal. Beaker is designed to simplify writing, testing and deploying Algorand smart contracts. The Beaker source code available on [github](https://github.com/algorand-devrel/beaker). 
 
 This page provides an overview of the features available in Beaker. For complete details see the [Beaker's documentation](https://beaker.algo.xyz). 

--- a/docs/get-details/dapps/writing-contracts/pyteal.md
+++ b/docs/get-details/dapps/writing-contracts/pyteal.md
@@ -1,5 +1,8 @@
 title: PyTeal
 
+!!! note
+For a native Python experience, checkout our [Algorand Python](https://algorandfoundation.github.io/puya/) docs.
+
 [PyTeal](https://github.com/algorand/pyteal) is a python library for generating [TEAL](/docs/get-details/dapps/avm/teal/) programs that provides a convenient and familiar syntax. 
 
 Complete installation instructions and developer guides are available in the [PyTeal documentation](https://pyteal.readthedocs.io/en/latest/).

--- a/docs/get-details/dapps/writing-contracts/python.md
+++ b/docs/get-details/dapps/writing-contracts/python.md
@@ -1,0 +1,3 @@
+title: Python
+
+Follow [this](https://algorandfoundation.github.io/puya/) link for the Algorand Python GitHub docs.


### PR DESCRIPTION
After numerous complications ingesting the docs into the developer portal, we'll link to the original docs for now and work on a better automated solution after launch.

Also added a note to both PyTeal and Beaker pages.