### PR TITLE
Add new reviewers

### DIFF
--- a/.github/workflows/pr-generator.yml
+++ b/.github/workflows/pr-generator.yml
@@ -134,6 +134,6 @@ jobs:
           branch: "automatic-pr-go-algorand-${{ inputs.go_algorand_version }}-indexer-${{ inputs.indexer_version }}"
           title: "Automatic update generated for go-algorand: ${{ inputs.go_algorand_version }} and indexer: ${{ inputs.indexer_version }}"
           body: "Changes generated automatically by github action docs-generator."
-          reviewers: "nullun"
+          reviewers: "nullun,SilentRhetoric,Loedn,larkiny"
           delete-branch: true
           base: staging


### PR DESCRIPTION
This workflow creates a new PR when a new go-algorand or indexer release is made. It automatically updates the docs based on the latest REST API, Configuration values, or CLI changes. Probably other changes too. This PR is adding additional reviewers.