### PR TITLE
The pr-generator workflow is failing as these users are non-contributors

### DIFF
--- a/.github/workflows/pr-generator.yml
+++ b/.github/workflows/pr-generator.yml
@@ -134,6 +134,6 @@ jobs:
           branch: "automatic-pr-go-algorand-${{ inputs.go_algorand_version }}-indexer-${{ inputs.indexer_version }}"
           title: "Automatic update generated for go-algorand: ${{ inputs.go_algorand_version }} and indexer: ${{ inputs.indexer_version }}"
           body: "Changes generated automatically by github action docs-generator."
-          reviewers: "nullun,SilentRhetoric,Loedn,larkiny"
+          reviewers: "nullun,SilentRhetoric"
           delete-branch: true
           base: staging


### PR DESCRIPTION
> Error: Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the algorandfoundation/docs repository.