### PR TITLE
Fixed correct deploy command

### DIFF
--- a/docs/get-started/algokit.md
+++ b/docs/get-started/algokit.md
@@ -153,7 +153,7 @@ If you would like to manually build and deploy the `HelloWorld` smart contract r
 
 ```shell
 algokit project run build
-algokit project run deploy 
+algokit project deploy 
 ```
 
 This should produce something similar to the following in the VSCode terminal.


### PR DESCRIPTION
The command  old command triggers error (Command not found), and following the CLI help, this one is the correct one